### PR TITLE
Update template-binary.json

### DIFF
--- a/monolith/src/main/openshift/template-binary.json
+++ b/monolith/src/main/openshift/template-binary.json
@@ -120,7 +120,7 @@
                         "from": {
                             "kind": "ImageStreamTag",
                             "namespace": "${IMAGE_STREAM_NAMESPACE}",
-                            "name": "jboss-eap70-openshift:1.6"
+                            "name": "jboss-eap71-openshift:latest"
                         }
                     }
                 },


### PR DESCRIPTION
All the 1st tutorial talks about jboss 7.1 but the OCP building image reported on this reports 7.0 and apparently I could not build coolstore by using this jboss version whilst I was able to build coolstore at the 1st try by changing the building image from 7.0 to 7.1; kindly review my change, thanks.